### PR TITLE
Fix broken donation link on contact page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -66,7 +66,7 @@
             <h2>Support Our Work</h2>
             
             <p>We are also grateful to all financial supporters of our work. Financial
-               contributions can be made through Vanderbilt University at <a href="http://www.vu.edu/syriac">www.vu.edu/syriac</a> or by contacting
+               contributions can be made through Vanderbilt University by contacting
                <a href="mailto:info@syriaca.org">info@syriaca.org</a>.
             </p>
             


### PR DESCRIPTION
Fixed broken donation link on the Contact Us page.

## Problem
The donation link `http://www.vu.edu/syriac` returns a 404 error.

## Solution
Removed the broken link while preserving the donation information. Users can still make financial contributions by contacting `info@syriaca.org`.

Closes #130

---

If this PR helped your project, tips are appreciated! 🙏
USDT (TRC20): `TJL2uq9nC6aqqGTDSUaUg8KWepSh8htrft`